### PR TITLE
Loading Proxy

### DIFF
--- a/cmd/run/main.go
+++ b/cmd/run/main.go
@@ -17,10 +17,12 @@ import (
 var workDir string = "./"
 var outDir string = "./out"
 var resume string = ""
-var graph  string = ""
+var graph string = ""
 var toStdout bool
 var keep bool
 var cmdInputs map[string]string
+
+var proxy = ""
 
 // Cmd is the declaration of the command line
 var Cmd = &cobra.Command{
@@ -28,6 +30,11 @@ var Cmd = &cobra.Command{
 	Short: "Run importer",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var lps *LoadProxyServer
+		if proxy != "" {
+			lps = NewLoadProxyServer(proxy)
+			lps.Start()
+		}
 
 		if _, err := os.Stat(outDir); os.IsNotExist(err) {
 			os.MkdirAll(outDir, 0777)
@@ -37,7 +44,7 @@ var Cmd = &cobra.Command{
 		if toStdout {
 			driver = "stdout://"
 		}
-		if graph != ""  {
+		if graph != "" {
 			driver = graph
 		}
 
@@ -86,6 +93,9 @@ var Cmd = &cobra.Command{
 		if !keep {
 			os.RemoveAll(dir)
 		}
+		if lps != nil {
+			lps.StartProxy()
+		}
 		return nil
 	},
 }
@@ -98,6 +108,8 @@ func init() {
 	flags.StringVarP(&outDir, "out", "o", outDir, "Output Dir")
 	flags.StringVarP(&resume, "resume", "r", resume, "Resume Directory")
 	flags.StringVarP(&graph, "graph", "g", graph, "Output to graph")
+
+	flags.StringVar(&proxy, "proxy", proxy, "Proxy site")
 
 	flags.StringToStringVarP(&cmdInputs, "inputs", "i", cmdInputs, "Input variables")
 }

--- a/cmd/run/main.go
+++ b/cmd/run/main.go
@@ -23,6 +23,7 @@ var keep bool
 var cmdInputs map[string]string
 
 var proxy = ""
+var port = 8888
 
 // Cmd is the declaration of the command line
 var Cmd = &cobra.Command{
@@ -32,7 +33,7 @@ var Cmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var lps *LoadProxyServer
 		if proxy != "" {
-			lps = NewLoadProxyServer(proxy)
+			lps = NewLoadProxyServer(port, proxy)
 			lps.Start()
 		}
 
@@ -55,6 +56,9 @@ var Cmd = &cobra.Command{
 		if err != nil {
 			log.Printf("Error stating load manager: %s", err)
 			return err
+		}
+		if lps != nil {
+			ld = loader.NewLoadCounter(ld, 1000, func(i uint64) { lps.UpdateCount(i) })
 		}
 		defer ld.Close()
 
@@ -110,6 +114,6 @@ func init() {
 	flags.StringVarP(&graph, "graph", "g", graph, "Output to graph")
 
 	flags.StringVar(&proxy, "proxy", proxy, "Proxy site")
-
+	flags.IntVar(&port, "port", port, "Proxy Port")
 	flags.StringToStringVarP(&cmdInputs, "inputs", "i", cmdInputs, "Input variables")
 }

--- a/cmd/run/proxy.go
+++ b/cmd/run/proxy.go
@@ -1,0 +1,47 @@
+package run
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sync"
+)
+
+type LoadProxyServer struct {
+	DestURL    string
+	waitScreen bool
+	group      *sync.WaitGroup
+	proxy      *httputil.ReverseProxy
+}
+
+func NewLoadProxyServer(proxyURL string) *LoadProxyServer {
+	rpURL, _ := url.Parse(proxyURL)
+
+	return &LoadProxyServer{DestURL: proxyURL, group: &sync.WaitGroup{}, waitScreen: true, proxy: httputil.NewSingleHostReverseProxy(rpURL)}
+}
+
+func (lp *LoadProxyServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	if lp.waitScreen {
+		res.Header().Set("Content-Type", "text/html; charset=utf-8")
+		data := []byte(`<html><meta http-equiv="refresh" content="5" />Sifter Loading Data</html>`)
+		res.Write(data)
+	} else {
+		lp.proxy.ServeHTTP(res, req)
+	}
+}
+
+func (lp *LoadProxyServer) Start() error {
+	// create a new handler
+	lp.group.Add(1)
+	go func() {
+		http.ListenAndServe(":9999", lp)
+		lp.group.Done()
+	}()
+	return nil
+}
+
+func (lp *LoadProxyServer) StartProxy() error {
+	lp.waitScreen = false
+	lp.group.Wait()
+	return nil
+}

--- a/cmd/run/proxy.go
+++ b/cmd/run/proxy.go
@@ -26,7 +26,7 @@ func NewLoadProxyServer(port int, proxyURL string) *LoadProxyServer {
 func (lp *LoadProxyServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	if lp.waitScreen {
 		res.Header().Set("Content-Type", "text/html; charset=utf-8")
-		page := fmt.Sprintf(`<html><meta http-equiv="refresh" content="5" />Sifter Loading Data. %d elements loaded</html>`, lp.count)
+		page := fmt.Sprintf(`<html><meta http-equiv="refresh" content="5" /><div style="height: 100%%; margin: auto; text-align: center;"><div>Sifter Loading Data</div><div>%d elements loaded</div></div></html>`, lp.count)
 		data := []byte(page)
 		res.Write(data)
 	} else {

--- a/loader/counter.go
+++ b/loader/counter.go
@@ -1,0 +1,78 @@
+package loader
+
+import (
+	"sync/atomic"
+
+	"github.com/bmeg/grip/gripql"
+	"github.com/bmeg/sifter/schema"
+)
+
+type CountLoader struct {
+	l        Loader
+	rate     uint64
+	callback func(uint64)
+	count    uint64
+}
+
+type CountDataEmitter struct {
+	d  DataEmitter
+	cl *CountLoader
+}
+
+type CountGraphEmitter struct {
+	g  GraphEmitter
+	cl *CountLoader
+}
+
+func NewLoadCounter(l Loader, rate uint64, callback func(uint64)) Loader {
+	return &CountLoader{l: l, rate: rate, callback: callback}
+}
+
+func (cl *CountLoader) Close() {
+	cl.l.Close()
+}
+
+func (cl *CountLoader) NewDataEmitter(sch *schema.Schemas) (DataEmitter, error) {
+	o, err := cl.l.NewDataEmitter(sch)
+	return &CountDataEmitter{o, cl}, err
+}
+
+func (cl *CountLoader) NewGraphEmitter() (GraphEmitter, error) {
+	o, err := cl.l.NewGraphEmitter()
+	return &CountGraphEmitter{o, cl}, err
+}
+
+func (cl *CountLoader) increment() {
+	v := atomic.AddUint64(&cl.count, 1)
+	if (v % cl.rate) == 0 {
+		cl.callback(v)
+	}
+}
+
+func (cd *CountDataEmitter) Close() {
+	cd.d.Close()
+}
+
+func (cd *CountDataEmitter) Emit(name string, e map[string]interface{}) error {
+	cd.cl.increment()
+	return cd.d.Emit(name, e)
+}
+
+func (cd *CountDataEmitter) EmitObject(prefix string, objClass string, e map[string]interface{}) error {
+	cd.cl.increment()
+	return cd.d.EmitObject(prefix, objClass, e)
+}
+
+func (cd *CountDataEmitter) EmitTable(prefix string, columns []string, sep rune) TableEmitter {
+	return cd.d.EmitTable(prefix, columns, sep)
+}
+
+func (cg *CountGraphEmitter) EmitVertex(v *gripql.Vertex) error {
+	cg.cl.increment()
+	return cg.g.EmitVertex(v)
+}
+
+func (cg *CountGraphEmitter) EmitEdge(e *gripql.Edge) error {
+	cg.cl.increment()
+	return cg.g.EmitEdge(e)
+}


### PR DESCRIPTION
Adds an option to the `run` command that sets up a website that first displays a loading screen and progress of sifter job until the playbook is done, then it starts up a reverse proxy to a website. 